### PR TITLE
Moving concept maps

### DIFF
--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -105,14 +105,33 @@ most of the complexities that a mechanical engineer would be concerned with.
 
 ![Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.](../fig/mental_models.svg)
 
-We will discuss the mental models of experts in more detail in [a later lesson]({{ page.root }}/03-expertise/).
+### Concept maps
+This kind of visual representation of concepts and connections between them can be a useful way to explore your own knowledge, evaluate comprehension, or
+communicate complex relationships. There are certain ways in which you may routinely use visual representations of abstract concepts, including tools like 
+flow charts and biochemical pathway diagrams. One tool that may be used to organize concepts and relationships more generally is a **concept map**. Pioneered for
+classroom use by John Novak in the 1970s, a concept map asks you identify which concepts are most relevant to your instructional question and -- critically -- to
+identify how they are related. It can be quite difficult to organize knowledge in this way! However, the process of forcing abstract knowledge into a visual 
+format can often reveal connections you may not have been aware of, or illuminate gaps. Either way, concept mapping can help you to make your mental model of a 
+concept more clear to yourself or others.
+
+### The power (and limitations) of analogies
+Some mental models can be succinctly summarized by comparison to something else that is more universally understood. In education, gardening analogies are
+pervasive because they rapidly convey characteristics that can otherwise be difficult to explain. Good analogies can be extraordinarily useful when teaching,
+because they draw upon an existing mental model to fill in another, speeding learning and making a memorable connection. However, all analogies have limitations!
+As with all models, "all... are wrong but some are useful." If you choose to use an analogy, be sure its usefulness outweighs its potential to generate harmful
+misconceptions. 
+
 
 > ## Your Mental Models
 >
-> In the Etherpad, write your primary research domain or area of expertise and some aspects of the mental model you use to frame
-> and understand your work. What concepts/facts are included? What types of relationships are included?
+> 1. Think of an analogy to explore. Perhaps you have one that relates to your area of professional interest, or a hobby. Or, maybe you would like to explore
+> the comparison of a teacher to a gardener. In the etherpad below, take a moment to explain what that analogy conveys about the topic. Then, take another moment
+> to identify a limitation where that analogy breaks down or could foster a misconception.
+>
+> 2. On a piece of paper, draw a concept map of the same concept, without the analogy. What are 3-4 core concepts involved? How are those concepts related?
 >  
-> This discussion should take about 5 minutes.
+> 3. Share your analogy with a partner, and describe the process of building the concept map. Have you learned anything about your mental model of the process 
+> at hand? If you were asked to teach this concept, would this influence how you would teach it?
 {: .challenge}
 
 One key insight from research on cognitive development is that

--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -80,7 +80,7 @@ your skill level. We will come back to the expertise of the instructor and its i
 For now, we are primarily concerned with novices,
 as this tends to characterize The Carpentries audience.
 
-It is common to think of a novice as a sort of an 'empty vessel' into which knowledge can be 'poured'. Unfortunately, this analogy has
+It is common to think of a novice as a sort of an "empty vessel" into which knowledge can be "poured." Unfortunately, this analogy has
 limited usefulness and is wrong in ways that generate dangerous misconceptions. In our next section, we will briefly explore the nature of "knowledge" through a concept
 that helps us differentiate between novices and competent practitioners in a more useful and visual way. This, in turn, will have implications
 for how we teach.
@@ -88,12 +88,12 @@ for how we teach.
 ## "All Models are Wrong, but Some are Useful"
 
 "Knowledge" is hard to describe. Understanding is never a mirror of reality, even for an expert; rather, it is 
-an internal representation based on our experience with a subject. Much of what we know is beyond our awareness, leading to things like "intuition". 
+an internal representation based on our experience with a subject. 
 This internal representation is often described as a **mental model**. A mental model
 allows us to extrapolate, or make predictions beyond and between the narrow limits of experience and memory, filling in 
 gaps to the point that things "make sense." 
 
-As we learn, we our mental model evolves to become more useful. A useful model makes reasonable predictions and fits well within
+As we learn, our mental model evolves to become more useful. A useful model makes reasonable predictions and fits well within
 the range of things
 we are likely to encounter, or at least does not break down entirely as new concepts are added. A driver of a gasoline powered car may 
 do just fine with a mental model that includes relationships between fuel, an engine, and a car battery;
@@ -104,22 +104,20 @@ of a broken alternator.
 
 
 ### The power (and limitations) of analogies
-Some mental models can be succinctly summarized by comparison to something else that is more universally understood. In education, gardening analogies are
-pervasive because they rapidly convey characteristics that can otherwise be difficult to explain. Good analogies can be extraordinarily useful when teaching,
+Some mental models can be succinctly summarized by comparison to something else that is more universally understood.  Good analogies can be extraordinarily useful when teaching,
 because they draw upon an existing mental model to fill in another, speeding learning and making a memorable connection. However, all analogies have limitations!
 If you choose to use an analogy, be sure its usefulness outweighs its potential to generate misconceptions. 
 
 > ## Analogy Brainstorm
 >
-> 1. Think of an analogy to explore. Perhaps you have a favorite that relates to your area of professional interest, or a hobby. Or, maybe you would like to 
-> explore the comparison of a teacher to a gardener. 
+> 1. Think of an analogy to explore. Perhaps you have a favorite that relates to your area of professional interest, or a hobby. If 
+> you prefer to work with an example, consider this common analogy from education: "teaching is like gardening."
 > 2. Share your analogy with a partner or group. (If you have not yet done so, be sure to take a moment to introduce yourself, first!) What does your analogy
 > convey about the topic? How is it useful? In what ways is it wrong?
 > This activity should take about 5 minutes.
 {: .challenge}
 
-A mental model may be represented as a collection of concepts and facts, connected by relationships. While this is not the way we naturally conceive
-such models in our brains, it is a useful way of exploring, characterizing, and communicating their key features.
+A mental model may be represented as a collection of concepts and facts, connected by relationships. 
 The mental model of an expert in any given subject will be far larger and more complex than that of a novice, including both more concepts 
 and more detailed and numerous relationships. However, **both may be perfectly useful** in certain contexts. 
 
@@ -138,7 +136,7 @@ still be missing or wrong, predictions about their area of work are usually accu
 Visual representation of concepts and relationships can be a useful way to explore, evaluate, or communicate when teaching.
 There are certain ways in which you may routinely use visual representations of abstract concepts, including tools like 
 flow charts and biochemical pathway diagrams. One tool that may be used to organize concepts and relationships more generally is a **concept map**. Pioneered for
-classroom use by John Novak in the 1970s, a concept map asks you identify which concepts are most relevant to your instructional question and -- critically -- to
+classroom use by John Novak in the 1970s, a concept map asks you to identify which concepts are most relevant to your instructional question and -- critically -- to
 identify how they are connected. It can be quite difficult to organize knowledge in this way! However, the process of forcing abstract knowledge into a visual 
 format can often reveal connections you may not have been aware of, or illuminate gaps. Especially where analogies are not available, concept mapping can help 
 you to make your mental model of a concept more clear to yourself or others.
@@ -150,7 +148,7 @@ you to make your mental model of a concept more clear to yourself or others.
 > 1. On a piece of paper, draw a concept map of the same concept you discussed in the last activity, but this time without the analogy. What are 3-4 core 
 > concepts involved? How are those concepts related?
 >  
-> 2. In the etherpad, write some notes on this process. Was it frustrating? Do you think it would be a useful exercise prior to teaching about your topic?
+> 2. In the Etherpad, write some notes on this process. Was it frustrating? Do you think it would be a useful exercise prior to teaching about your topic?
 > What would be necessary for a learner to complete such an exercise?
 {: .challenge}
 
@@ -162,14 +160,14 @@ presenting novices with a pile of facts early on is counter-productive,
 because they do not yet have a model or framework to fit those facts into.
 In fact,
 presenting too many facts too soon can actually reinforce
-an incorrect mental model. (This is a key problem with the "empty vessel" analogy described earlier.)
+an incorrect mental model. (This is a key problem with the "empty vessel" analogy.)
 
 Most learners coming to Carpentries lessons are novices,
 and do not have a strong mental model of the concepts we are teaching.
-Thus, our primary goal is *not*
-to teach the syntax of a particular programming language, but *to help them construct a working mental model*
-so that they have something to attach facts to. In other words, our goal is to teach people *how to think* about programming and data
-management in a way that will allow them to learn more on their own or understand what they might find online.
+Thus, our primary goal is **not**
+to teach the syntax of a particular programming language, but **to help them construct a working mental model**
+so that they have something to attach facts to. In other words, our goal is to teach people **how to think** about programming and data
+management in a way that will allow them to learn more easily on their own or understand what they might find online.
 
 ### The Importance of Going Slowly
 
@@ -271,7 +269,7 @@ This feedback comes through what we call *formative assessments* (in contrast
 > courses is summative, and is used to assign course grades.
 {: .callout}
 
-**Formative assessment** takes place during teaching and learning. It sounds like
+**Formative assessment** takes place during teaching and learning. It seems like
 a fancy term, but it can be used to describe any interaction or activity
 that provides feedback to both instructors and learners about learners' level of understanding of the
 material. For learners, this feedback can help focus their study efforts. For instructors, it allows them to refocus

--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -77,24 +77,25 @@ an arrow labelled "Experience level" points from left to right. Underneath the f
     presented with a problem, immediately sees how these skills can be used to solve the problem.
 
 Note that, while you may not think of yourself as a computational "expert," in the context above that term may accurately describe
-your skill level. We will come back to the expertise of the instructor in the next episode. 
+your skill level. We will come back to the expertise of the instructor and its impact -- positive and negative -- on teaching, in the next episode. 
 For now, we are primarily concerned with novices,
 as this tends to characterize The Carpentries audience.
 
-You might think of a novice as a sort of an 'empty vessel' into which knowledge can be 'poured'. Unfortunately, this analogy has
-very limited usefulness and generates dangerous misconceptions. In our next section, we will briefly explore the nature of "knowledge" through a concept
+It is common to think of a novice as a sort of an 'empty vessel' into which knowledge can be 'poured'. Unfortunately, this analogy has
+limited usefulness and is wrong in ways that generate dangerous misconceptions. In our next section, we will briefly explore the nature of "knowledge" through a concept
 that helps us differentiate between novices and competent practitioners in a more useful and visual way. This, in turn, will have implications
 for how we teach.
 
 ## "All Models are Wrong, but Some are Useful"
 
-"Knowledge" turns out to be a rather tricky thing to describe. Even for an expert, understanding is never a mirror of reality; rather, it is 
-a complicated construction of concepts and connections, much of which is beyond our awareness, leading to things like "intuition". 
-One way of conceptualizing our understanding of a topic is as a **mental model** - whatever reality may be, we have ideas about concepts and
-relationships and our minds put them together in a way that allows us to extrapolate, or make predictions beyond what we strictly know, filling in 
+"Knowledge" is hard to describe. Understanding is never a mirror of reality, even for an expert; rather, it is 
+an internal representation based on our experience with a subject. Much of what we know is beyond our awareness, leading to things like "intuition". 
+This internal representation is often described as a **mental model**. A mental model
+allows us to extrapolate, or make predictions beyond and between the narrow limits of experience and memory, filling in 
 gaps to the point that things "make sense." 
 
-As we learn, we create a mental model of a topic. A useful model is one that makes reasonable predictions and fits well with new things
+As we learn, we our mental model evolves to become more useful. A useful model makes reasonable predictions and fits well within
+the range of things
 we are likely to encounter, or at least does not break down entirely as new concepts are added. A driver of a gasoline powered car may 
 do just fine with a mental model that includes relationships between fuel, an engine, and a car battery;
 a broken alternator may not be something they could predict, but learning that another part mediates the relationship 
@@ -102,9 +103,6 @@ between the engine and the battery adds to the model without the driver having t
 Alternatively, a child who attributes sentient will to a vehicle will have to work much harder to make sense 
 of a broken alternator.
 
-A mental model may be understood as a collection of concepts and facts, connected by relationships. 
-The mental model of an expert in any given subject will be far more complex than that of a novice, including both more concepts 
-and more detailed and numerous relationships. However, **both may be perfectly useful** in certain contexts. 
 
 ### The power (and limitations) of analogies
 Some mental models can be succinctly summarized by comparison to something else that is more universally understood. In education, gardening analogies are
@@ -121,14 +119,18 @@ If you choose to use an analogy, be sure its usefulness outweighs its potential 
 > This activity should take about 5 minutes.
 {: .challenge}
 
+A mental model may be represented as a collection of concepts and facts, connected by relationships. While this is not the way we naturally conceive
+such models in our brains, it is a useful way of exploring, characterizing, and communicating their key features.
+The mental model of an expert in any given subject will be far larger and more complex than that of a novice, including both more concepts 
+and more detailed and numerous relationships. However, **both may be perfectly useful** in certain contexts. 
 
-Mental models can be applied to explain levels of skill development: 
-*     A *novice* is someone who has a minimal and potentially inaccurate mental model of surface features of the domain.
-They therefore reason by analogy and guesswork,
-borrowing bits and pieces of their mental models of other domains
-which seem superficially similar. New information can be difficult to connect, especially where the existing model is wrong.
-*     A *competent practitioner* is someone who has a mental model that is useful for everyday purposes. Most new information
-they are likely to encounter will fit well with their existing model, even though many related elements may still be missing or wrong.
+Returning to our example levels of skill development: 
+*     A *novice* has a minimal mental model of surface features of the domain. Inaccuracies may interfere with adding new information.
+Predictions are likely to borrow heavily from mental models of other domains
+which seem superficially similar.
+*     A *competent practitioner* has a mental model that is useful for everyday purposes. Most new information
+they are likely to encounter will fit well with their existing model. Even though many potential elements of their mental model may
+still be missing or wrong, predictions about their area of work are usually accurate.
 
 ![Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.](../fig/mental_models.svg)
 

--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -49,8 +49,7 @@ who applied the [Dreyfus model of skill acquisition][wikipedia-dreyfus-skill]
 in her studies of
 [how nurses progress from novice to expert](http://journals.sagepub.com/doi/10.1177/0270467604265061)
 ([see also books by Benner](https://www.worldcat.org/search?q=au%3ABenner%2C+Patricia+E.&qt=hot_author)). This work indicates that
-through practice and formal instruction, learners acquire skills and advance through distinct stages. In simplified form,
-the three stages of this model are:
+through practice and formal instruction, learners acquire skills and advance through distinct stages. In simplified form, three stages of this model are:
 
 ![Three people, labeled from left to right as "Novice", "Competent Practitioner", and "Expert". Underneath the people,
 an arrow labelled "Experience level" points from left to right. Underneath the figure labelled "Novice" a quote says "I'm not sure what questions to ask." The Competent Practitioner says "I'm pretty confident, but I still look stuff up a lot!" The Expert says "I've been doing this on a daily basis for years!"](../fig/skill-level.svg)
@@ -163,7 +162,7 @@ presenting novices with a pile of facts early on is counter-productive,
 because they do not yet have a model or framework to fit those facts into.
 In fact,
 presenting too many facts too soon can actually reinforce
-an incorrect mental model.
+an incorrect mental model. (This is a key problem with the "empty vessel" analogy described earlier.)
 
 Most learners coming to Carpentries lessons are novices,
 and do not have a strong mental model of the concepts we are teaching.

--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -57,14 +57,15 @@ an arrow labelled "Experience level" points from left to right. Underneath the f
 
 *   *Novice*: someone who does not know what they do not know, i.e.,
     they do not yet know what the key ideas in the domain are or how they relate.
-    One sign that someone is a novice is that their questions "are not even wrong".
+    Novices may have difficulty formulating questions, or may ask questions that seem irrelevant or off-topic
+    as they reach for anything they know to connect.
 
     > Example: A *novice* learner in a Carpentries workshop might never have heard of the bash shell, and therefore
     may have no understanding of how it relates to their file system or other programs on their computer.
 
 *   *Competent practitioner*: someone who has enough understanding for everyday purposes. They will not know all the details
-of how something works and their understanding may not be entirely accurate, but it is sufficient for completing normal
-tasks with normal effort under normal circumstances.
+    of how something works and their understanding may not be entirely accurate, but it is sufficient for completing normal
+    tasks with normal effort under normal circumstances.
 
     > Example: A *competent practitioner* in a Carpentries workshop might have used the shell before and understand how to
     move around directories and use individual programs, but they might not understand how they can fit these programs
@@ -75,12 +76,15 @@ tasks with normal effort under normal circumstances.
     > Example: An *expert* in a Carpentries workshop may have experience writing and running shell scripts and, when
     presented with a problem, immediately sees how these skills can be used to solve the problem.
 
+Note that, while you may not think of yourself as a computational "expert," in the context above that term may accurately describe
+your skill level. We will come back to the expertise of the instructor in the next episode. 
 For now, we are primarily concerned with novices,
-as this tends to characterize The Carpentries audience. (We, as instructors,
-  are more likely to be competent practitioners or experts, and we will
-discuss this in a later section).  We will next use an additional concept
-to help us differentiate between novices and competent practitioners, which will have
-implications for how we teach novices.
+as this tends to characterize The Carpentries audience.
+
+You might think of a novice as a sort of an 'empty vessel' into which knowledge can be 'poured'. Unfortunately, this analogy has
+very limited usefulness and generates dangerous misconceptions. In our next section, we will briefly explore the nature of "knowledge" through a concept
+that helps us differentiate between novices and competent practitioners in a more useful and visual way. This, in turn, will have implications
+for how we teach.
 
 ## "All Models are Wrong, but Some are Useful"
 
@@ -90,22 +94,25 @@ One way of conceptualizing our understanding of a topic is as a **mental model**
 relationships and our minds put them together in a way that allows us to extrapolate, or make predictions beyond what we strictly know, filling in 
 gaps to the point that things "make sense." 
 
-Effective learning is facilitated by the creation of a mental model that makes reasonable predictions in our area of interest, or at the very least
-does not break down entirely in the face of new information. A driver may get by just fine with a mental model that includes fuel, an engine, and a car battery;
-an alternator failure may not be something they could explicitly predict, but it is reasonable in that context that another part might broker the relationship 
-between the engine and the battery. Alternatively, a child who attributes sentient will to a vehicle will have to work much harder to make sense 
-of such a problem.
+As we learn, we create a mental model of a topic. A useful model is one that makes reasonable predictions and fits well with new things
+we are likely to encounter, or at least does not break down entirely as new concepts are added. A driver of a gasoline powered car may 
+do just fine with a mental model that includes relationships between fuel, an engine, and a car battery;
+a broken alternator may not be something they could predict, but learning that another part mediates the relationship 
+between the engine and the battery adds to the model without the driver having to add any other concepts or un-learn mis-conceived relationships. 
+Alternatively, a child who attributes sentient will to a vehicle will have to work much harder to make sense 
+of a broken alternator.
 
-A mental model may be understood as a collection of concepts and facts, along with the relationships between those concepts, which a person has about a topic. 
-The mental model of an expert in any given subject will be far more complex than that of a novice, though both may be perfectly useful in certain contexts. 
+A mental model may be understood as a collection of concepts and facts, connected by relationships. 
+The mental model of an expert in any given subject will be far more complex than that of a novice, including both more concepts 
+and more detailed and numerous relationships. However, **both may be perfectly useful** in certain contexts. 
 
 ### The power (and limitations) of analogies
 Some mental models can be succinctly summarized by comparison to something else that is more universally understood. In education, gardening analogies are
 pervasive because they rapidly convey characteristics that can otherwise be difficult to explain. Good analogies can be extraordinarily useful when teaching,
 because they draw upon an existing mental model to fill in another, speeding learning and making a memorable connection. However, all analogies have limitations!
-If you choose to use an analogy, be sure its usefulness outweighs its potential to generate harmful misconceptions. 
+If you choose to use an analogy, be sure its usefulness outweighs its potential to generate misconceptions. 
 
-> ## Breaking Down Analogies
+> ## Analogy Brainstorm
 >
 > 1. Think of an analogy to explore. Perhaps you have a favorite that relates to your area of professional interest, or a hobby. Or, maybe you would like to 
 > explore the comparison of a teacher to a gardener. 
@@ -115,7 +122,7 @@ If you choose to use an analogy, be sure its usefulness outweighs its potential 
 {: .challenge}
 
 
-Mental models can also help us to better understand different levels of skill development: 
+Mental models can be applied to explain levels of skill development: 
 *     A *novice* is someone who has a minimal and potentially inaccurate mental model of surface features of the domain.
 They therefore reason by analogy and guesswork,
 borrowing bits and pieces of their mental models of other domains
@@ -127,8 +134,8 @@ they are likely to encounter will fit well with their existing model, even thoug
 
 
 ### Concept maps
-Visual representation of concepts and relationships can be a useful way to explore your own knowledge, evaluate comprehension, or
-communicate complex relationships. There are certain ways in which you may routinely use visual representations of abstract concepts, including tools like 
+Visual representation of concepts and relationships can be a useful way to explore, evaluate, or communicate when teaching.
+There are certain ways in which you may routinely use visual representations of abstract concepts, including tools like 
 flow charts and biochemical pathway diagrams. One tool that may be used to organize concepts and relationships more generally is a **concept map**. Pioneered for
 classroom use by John Novak in the 1970s, a concept map asks you identify which concepts are most relevant to your instructional question and -- critically -- to
 identify how they are connected. It can be quite difficult to organize knowledge in this way! However, the process of forcing abstract knowledge into a visual 
@@ -194,17 +201,16 @@ That mental model of the shell also includes things like:
     (This motivates the pipe-and-filter model.)
 
 These two examples illustrate something else as well.
-Learning consists of more than "just" building mental models
-and adding information to them;
+Learning consists of more than "just" adding information to mental models;
 creating linkages between concepts and facts is at least as important.
 Telling people that they should not repeat things,
-and that they should try to think in terms of little pieces loosely joined,
+and that they should try to think (by analogy) in terms of little pieces loosely joined,
 both set the stage for discussing functions.
 Explicitly referring back to pipes and filters in the shell when introducing functions
 helps solidify both ideas.
 
 > ## Meeting Learners Where They Are
-> One of the strengths of Carpentries workshops is that we meet learners where they are at. Carpentries Instructors
+> One of the strengths of Carpentries workshops is that we meet learners *where they are*. Carpentries Instructors
 > strive to help learners
 > progress from whatever starting point they happen to be at, without making anyone
 > feel inferior about their current practices or skillsets. We do this in part by teaching relevant and useful skills
@@ -240,7 +246,7 @@ Broadly speaking, misconceptions fall into three categories:
 
 Since The Carpentries workshops are focused on novices, and the building of
 strong mental models, we are most interested in the middle category of misconceptions.
-While teaching, we want to expose learners' broken models so that we can help them build better ones.
+While teaching, we want to expose learners' broken models so that we can help them to deconstruct them and build better ones in their place.
 
 ## Identifying and Correcting Misconceptions
 
@@ -248,7 +254,7 @@ How do we expose misconceptions, especially as they pertain to broken models? Ho
 can we, in-class, know whether the learners already understand this topic
 (so that the class can move on),
 and if not,
-what misconceptions and gaps in their knowledge we should address.
+what misconceptions and gaps in their knowledge we should address?
 
 To be effective, instructors need feedback on their learners' progress,
 and insight into their learners' mental models.
@@ -264,7 +270,7 @@ This feedback comes through what we call *formative assessments* (in contrast
 > courses is summative, and is used to assign course grades.
 {: .callout}
 
-*Formative assessment* takes place during teaching and learning. It sounds like
+**Formative assessment** takes place during teaching and learning. It sounds like
 a fancy term, but it can be used to describe any interaction or activity
 that provides feedback to both instructors and learners about learners' level of understanding of the
 material. For learners, this feedback can help focus their study efforts. For instructors, it allows them to refocus
@@ -380,10 +386,12 @@ Knowing how to respond to the results of a formative assessment is a skill that 
 
 > ## Modeling Novice Mental Models
 >
-> Take 10 minutes to create a multiple choice question related to a topic you intend to teach.
-> Type it into the Etherpad
-> and explain the diagnostic power of each its distractors,
-> i.e., what misconception is each distractor meant to identify?
+> Take 10 minutes to create a multiple choice question related to a lesson you intend to teach.
+> 1. Think about the topic of the lesson. What relevant misconceptions might a novice learner bring to the classroom? 
+> In what ways might they misunderstand or inappropriately connect concepts?
+> 2. Try to target one or more misconceptions using a multiple choice question. How many diagnostic distractors can you create?
+> 3. Type your question into the Etherpad
+> and explain the diagnostic power of each its distractors.
 {: .challenge}
 
 > ## A Note on MCQ Design

--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -82,37 +82,32 @@ discuss this in a later section).  We will next use an additional concept
 to help us differentiate between novices and competent practitioners, which will have
 implications for how we teach novices.
 
-## Cognitive Development and Mental Models
+## "All Models are Wrong, but Some are Useful"
 
-Effective learning is facilitated by the creation of a well-founded mental model. A mental model is a collection of concepts and facts,
-along with the relationships between those concepts, which a person has about a topic. For example, a long-time resident of the United
-States may have an advanced understanding of the location of US states, major cities and landmarks, weather patterns, regional
-economies and demographic patterns, as well as the relationships among these, compared with their understanding of these relationships
-for other countries. In other words, their mental model of the United States is more complex compared with their mental model of other
-countries.
+"Knowledge" turns out to be a rather tricky thing to describe. Even for an expert, understanding is never a mirror of reality; rather, it is 
+a complicated construction of concepts and connections, much of which is beyond our awareness, leading to things like "intuition". 
+One way of conceptualizing our understanding of a topic is as a **mental model** - whatever reality may be, we have ideas about concepts and
+relationships and our minds put them together in a way that allows us to extrapolate, or make predictions beyond what we strictly know, filling in 
+gaps to the point that things "make sense." 
 
-We can distinguish between a *novice* and a *competent
-practitioner* for a given domain based on the complexity of their mental models.
+Effective learning is facilitated by the creation of a mental model that makes reasonable predictions in our area of interest, or at the very least
+does not break down entirely in the face of new information. A driver may get by just fine with a mental model that includes fuel, an engine, and a car battery;
+an alternator failure may not be something they could explicitly predict, but it is reasonable in that context that another part might broker the relationship 
+between the engine and the battery. Alternatively, a child who attributes sentient will to a vehicle will have to work much harder to make sense 
+of such a problem.
 
-*     A *novice* is someone who has not yet built a mental model of the domain.
+A mental model may be understood as a collection of concepts and facts, along with the relationships between those concepts, which a person has about a topic. 
+The mental model of an expert in any given subject will be far more complex than that of a novice, though both may be perfectly useful in certain contexts. 
+
+We can also, then, define skill levels according to the level of mental model development: 
+*     A *novice* is someone who has a minimal and potentially inaccurate mental model of surface features of the domain.
 They therefore reason by analogy and guesswork,
 borrowing bits and pieces of their mental models of other domains
-which seem superficially similar.
-*     A *competent practitioner* is someone who has a mental model that is good enough for everyday purposes. This model
-does not have to be completely accurate in order to be useful:
-for example, the average driver's mental model of how a car works probably does not include
-most of the complexities that a mechanical engineer would be concerned with.
+which seem superficially similar. New information can be difficult to connect, especially where the existing model is wrong.
+*     A *competent practitioner* is someone who has a mental model that is useful for everyday purposes. Most new information
+they are likely to encounter will fit well with their existing model, even though many related elements may still be missing or wrong.
 
 ![Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.](../fig/mental_models.svg)
-
-### Concept maps
-This kind of visual representation of concepts and connections between them can be a useful way to explore your own knowledge, evaluate comprehension, or
-communicate complex relationships. There are certain ways in which you may routinely use visual representations of abstract concepts, including tools like 
-flow charts and biochemical pathway diagrams. One tool that may be used to organize concepts and relationships more generally is a **concept map**. Pioneered for
-classroom use by John Novak in the 1970s, a concept map asks you identify which concepts are most relevant to your instructional question and -- critically -- to
-identify how they are related. It can be quite difficult to organize knowledge in this way! However, the process of forcing abstract knowledge into a visual 
-format can often reveal connections you may not have been aware of, or illuminate gaps. Either way, concept mapping can help you to make your mental model of a 
-concept more clear to yourself or others.
 
 ### The power (and limitations) of analogies
 Some mental models can be succinctly summarized by comparison to something else that is more universally understood. In education, gardening analogies are
@@ -121,18 +116,35 @@ because they draw upon an existing mental model to fill in another, speeding lea
 As with all models, "all... are wrong but some are useful." If you choose to use an analogy, be sure its usefulness outweighs its potential to generate harmful
 misconceptions. 
 
-
-> ## Your Mental Models
+> ## Breaking Down Analogies
 >
-> 1. Think of an analogy to explore. Perhaps you have one that relates to your area of professional interest, or a hobby. Or, maybe you would like to explore
-> the comparison of a teacher to a gardener. In the etherpad below, take a moment to explain what that analogy conveys about the topic. Then, take another moment
-> to identify a limitation where that analogy breaks down or could foster a misconception.
->
-> 2. On a piece of paper, draw a concept map of the same concept, without the analogy. What are 3-4 core concepts involved? How are those concepts related?
->  
-> 3. Share your analogy with a partner, and describe the process of building the concept map. Have you learned anything about your mental model of the process 
-> at hand? If you were asked to teach this concept, would this influence how you would teach it?
+> 1. Think of an analogy to explore. Perhaps you have a favorite that relates to your area of professional interest, or a hobby. Or, maybe you would like to 
+> explore the comparison of a teacher to a gardener. 
+> 2. Share your analogy with a partner or group. (If you have not yet done so, be sure to take a moment to introduce yourself, first!) What does your analogy
+> convey about the topic? How is it useful? In what ways is it wrong?
+> This activity should take about 5 minutes.
 {: .challenge}
+
+### Concept maps
+Visual representation of concepts and relationships can be a useful way to explore your own knowledge, evaluate comprehension, or
+communicate complex relationships. There are certain ways in which you may routinely use visual representations of abstract concepts, including tools like 
+flow charts and biochemical pathway diagrams. One tool that may be used to organize concepts and relationships more generally is a **concept map**. Pioneered for
+classroom use by John Novak in the 1970s, a concept map asks you identify which concepts are most relevant to your instructional question and -- critically -- to
+identify how they are connected. It can be quite difficult to organize knowledge in this way! However, the process of forcing abstract knowledge into a visual 
+format can often reveal connections you may not have been aware of, or illuminate gaps. Especially where analogies are not available, concept mapping can help 
+you to make your mental model of a concept more clear to yourself or others.
+
+![Four words inside circles, with labeled arrows connecting them. "Car" is at the top, with an arrow pointing to "engine" labeled as "is powered by." An arrow connects "engine" to "fuel," at left, labeled "requires energy from." Another arrow connects "engine" to "battery," at right, labeled "charges." An arrow connects "battery" back to "car," labeled "is needed to start."](../fig/Cmap-Car.svg)
+
+> ## Mapping a Mental Model
+>
+> 1. On a piece of paper, draw a concept map of the same concept you discussed in the last activity, but this time without the analogy. What are 3-4 core 
+> concepts involved? How are those concepts related?
+>  
+> 2. In the etherpad, write some notes on this process. Was it frustrating? Do you think it would be a useful exercise prior to teaching about your topic?
+> What would be necessary for a learner to complete such an exercise?
+{: .challenge}
+
 
 One key insight from research on cognitive development is that
 novices, competent practitioners, and experts each need to be taught differently.

--- a/_episodes/02-practice-learning.md
+++ b/_episodes/02-practice-learning.md
@@ -99,22 +99,11 @@ of such a problem.
 A mental model may be understood as a collection of concepts and facts, along with the relationships between those concepts, which a person has about a topic. 
 The mental model of an expert in any given subject will be far more complex than that of a novice, though both may be perfectly useful in certain contexts. 
 
-We can also, then, define skill levels according to the level of mental model development: 
-*     A *novice* is someone who has a minimal and potentially inaccurate mental model of surface features of the domain.
-They therefore reason by analogy and guesswork,
-borrowing bits and pieces of their mental models of other domains
-which seem superficially similar. New information can be difficult to connect, especially where the existing model is wrong.
-*     A *competent practitioner* is someone who has a mental model that is useful for everyday purposes. Most new information
-they are likely to encounter will fit well with their existing model, even though many related elements may still be missing or wrong.
-
-![Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.](../fig/mental_models.svg)
-
 ### The power (and limitations) of analogies
 Some mental models can be succinctly summarized by comparison to something else that is more universally understood. In education, gardening analogies are
 pervasive because they rapidly convey characteristics that can otherwise be difficult to explain. Good analogies can be extraordinarily useful when teaching,
 because they draw upon an existing mental model to fill in another, speeding learning and making a memorable connection. However, all analogies have limitations!
-As with all models, "all... are wrong but some are useful." If you choose to use an analogy, be sure its usefulness outweighs its potential to generate harmful
-misconceptions. 
+If you choose to use an analogy, be sure its usefulness outweighs its potential to generate harmful misconceptions. 
 
 > ## Breaking Down Analogies
 >
@@ -124,6 +113,18 @@ misconceptions.
 > convey about the topic? How is it useful? In what ways is it wrong?
 > This activity should take about 5 minutes.
 {: .challenge}
+
+
+Mental models can also help us to better understand different levels of skill development: 
+*     A *novice* is someone who has a minimal and potentially inaccurate mental model of surface features of the domain.
+They therefore reason by analogy and guesswork,
+borrowing bits and pieces of their mental models of other domains
+which seem superficially similar. New information can be difficult to connect, especially where the existing model is wrong.
+*     A *competent practitioner* is someone who has a mental model that is useful for everyday purposes. Most new information
+they are likely to encounter will fit well with their existing model, even though many related elements may still be missing or wrong.
+
+![Three collections of six circles. The first collection is labelled "Novice" and has only two arrows connecting some of the circles. The second collection, labelled "Competent Practitioner" has six connecting arrows. The third collection, labelled "Expert", is densly connected, with eight connecting arrows.](../fig/mental_models.svg)
+
 
 ### Concept maps
 Visual representation of concepts and relationships can be a useful way to explore your own knowledge, evaluate comprehension, or

--- a/_episodes/05-memory.md
+++ b/_episodes/05-memory.md
@@ -124,8 +124,8 @@ In the same vein as "going slowly," it is important to limit the number of
 concepts introduced in a lesson; no matter how many exercises or formative
 assessments you do, you cannot overcome the limit of items that can be
 shored in short-term memory. Planning your lesson with a concept map can help you 
-not only identify key concepts and relationships, but also to notice when you are packing
-in too many things between assessments. 
+not only identify key concepts and relationships, but also to notice when you are trying to 
+teach too many things between assessments. 
 
 
 > ## Concept Maps in the Classroom

--- a/_episodes/05-memory.md
+++ b/_episodes/05-memory.md
@@ -123,109 +123,22 @@ assessments.
 In the same vein as "going slowly," it is important to limit the number of
 concepts introduced in a lesson; no matter how many exercises or formative
 assessments you do, you cannot overcome the limit of items that can be
-shored in short-term memory.
+shored in short-term memory. Planning your lesson with a concept map can help you 
+not only identify key concepts and relationships, but also to notice when you are packing
+in too many things between assessments. 
 
-## Concept Maps as Instructional Planning Tools
 
-One tool that can be used to identify the number of concepts being
-introduced in a lesson is the *concept map*.
-A concept map is a picture of someone's mental model of a domain:
-facts are bubbles,
-and connections are labelled arcs.
-It is important that they are labelled:
-saying "X and Y are related" is only helpful if we explain what the relationship *is*.
-
-To show what concept maps look like,
-consider this example of a `for` loop in Python:
-
-~~~
-for ch in "abc":
-    print(2*ch)
-~~~
-{: .source}
-
-The three key concepts used in this loop are:
-
-![Three rectangles labelled "loop variable", "collection", and "loop body".](../fig/for-loop-concepts.png)
-
-The key relationships,
-which are as important as the concepts themselves,
-are:
-
-!["Loop variable" is connected to "collection" with an arrow labelled "takes each value in order" and to "loop body" with an arrow labelled "changes each time". "Loop body" is connected to "collection" by an arrow reading "runs for each".](../fig/for-loop-arcs.png)
-
-A quick count shows that there are actually 6 things here,
-not just 3,
-so we are already brushing up against the limits of short-term memory.
-If we add two more facts to show things that are usually (but not always) true:
-
-![Two arrows are added to the previous figure, showing that the loop variable and collection are usually not changed by the loop body.](../fig/for-loop-rec.png)
-
-the count rises to 8,
-which is a good size for a single teaching episode.
-A few other concept maps drawn by previous participants in this training course
-are listed below:
-
-* [Array Math](../fig/array-math.png)
-* [Conditionals](../fig/conditionals.png)
-* [Creating and Destroying Files](../fig/create-destroy.png)
-* [Sets and Dictionaries in Python](../fig/dict-set.png)
-* [Input and Output](../fig/io.png)
-* [Lists and Loops](../fig/lists-loops.png)
-* [Git Version Control](../fig/git_concept_map.png)
-* [Library Carpentry Foundations](../fig/lc-foundations.png)
-
-Most of these are much larger than our recommended limit,
-but that is not necessarily a bad thing. An instructor can
-draw a concept map for an entire topic,
-and use that to decide where to introduce a formative assessment to avoid overloading
-short-term memory.
-
-It is very important to use a technique like concept mapping for a lesson
-before teaching it - an instructor needs to identify just how many pieces of
-separate information will need to be "stored" in memory during each part of the lesson. This
-can be particularly useful for experts who are trying to unpack their own
-knowledge.
-
-> ## Concept Mapping
->
-> Create a hand-drawn concept map for a part of a Carpentries lesson you would teach in
-> five minutes (i.e.
-> the amount of material you would teach before doing a formative assessment).
-> You can use the same subject about which you created a multiple choice question, or
-> a different subject.
-> Trade with a partner, and critique each other's maps. Are there any concepts
-> missing in your partner's map that you would include? Are there more than a handful
-> of concepts in your map? If so, how would you re-divide those concepts to avoid
-> overwhelming your learners' short-term memory?
->
-> Note for online trainings: please use a bold marker and write large so that your concept map 
-> can be shared on Zoom if you are prompted to do so.
->
-> Take 10 minutes to draw the concept maps and share with your neighbor.
-> Write "*done*" in the Etherpad chat once you have finished.
-{: .challenge}
-
-> ## Other Uses of Concept Maps
+> ## Concept Maps in the Classroom
 > In addition to helping you plan where to introduce formative assessments, concept maps can
 > be used in many other ways:
 >
-> 1.  To aid solo design of a lesson by helping authors figure
-> out what they are trying to teach.
+> 1.  To aid solo design of a lesson.
 > 2.  To aid communication with fellow lesson designers.
-> 3.  To aid communication with learners.
->     While it is possible to give learners a pre-drawn map at the start of a lesson for them
-> to annotate, it is better to draw it piece by piece while teaching
-> to reinforce the ties between what is in the map and what the instructor said.
-> 4. Concept maps can be used as a classroom discussion exercise.
-> 	Put learners in small groups (2-4 people each),
->	give each group some sticky notes on which a few key concepts are written,
->	and have them build a concept map on a whiteboard by placing those sticky notes,
->	connecting them with labelled arcs,
->	and adding any other concepts they think they need.
-> 5.  Concept maps are also a useful formative assessment technique:
->    having learners draw concept maps of what they think they just
-> heard shows the instructor what was missed and what was misunderstood.
+> 3.  To aid communication with learners. 
+> - When using a concept map as a communication aid, it is best to build the map piece by piece rather than providing it all at once.
+> 4.  As a classroom discussion exercise.
+> 5.  As a formative assessment technique.
+> - When asking learners to create a concept map, it is important to limit concepts and focus narrowly on target learning. Mind the (expert awareness) gap!
 {: .callout}
 
 ## Why Guided Practice is Important

--- a/fig/Cmap-Car.svg
+++ b/fig/Cmap-Car.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1295px" height="539px" style="background-color:#ffffff;">
+
+<!-- Connection Lines -->
+    <g>
+        <path d="M620 108L596.9738216156317 81.10471160735572" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <path d="M590 73L601.1033784403924 77.55137201395704L596.9738216156317 81.10471160735572L592.8442647908711 84.65805120075441Z" stroke="none" fill="#000000" stroke-width="1.5" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M663 158L633 123" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M596 173L638.3088847865106 172.14350490219448" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <path d="M649 172L638.382004186306 177.5909001869444L638.3088847865106 172.14350490219448L638.2357653867153 166.6961096174446Z" stroke="none" fill="#000000" stroke-width="1.5" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M498 174L553 173" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M356 203L325.3855292461874 210.45808724743665" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <path d="M315 213L324.0903600083619 205.16639579003547L325.3855292461874 210.45808724743665L326.68069848401285 215.7497787048378Z" stroke="none" fill="#000000" stroke-width="1.5" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M449 180L417 188" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M497 116L482.9543039210508 150.06601697882363" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <path d="M479 160L477.89268675691585 148.05119849601263L482.9543039210508 150.06601697882363L488.0159210851857 152.08083546163462Z" stroke="none" fill="#000000" stroke-width="1.5" stroke-dasharray="none" />
+    </g>
+    <g>
+        <path d="M563 70L512 101" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+    </g>
+
+<!-- Linking Phrases -->
+    <g>
+        <g>
+            <text x="579px" y="120px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>is</tspan><tspan fill="none">t</tspan><tspan>needed</tspan><tspan fill="none">t</tspan><tspan>to</tspan><tspan fill="none">t</tspan><tspan>start</tspan>
+            </text>
+        </g>
+    </g>
+    <g>
+        <g>
+            <text x="554px" y="177px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>charges</tspan>
+            </text>
+        </g>
+    </g>
+    <g>
+        <g>
+            <text x="329px" y="200px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>requires</tspan><tspan fill="none">t</tspan><tspan>energy</tspan><tspan fill="none">t</tspan><tspan>from</tspan>
+            </text>
+        </g>
+    </g>
+    <g>
+        <g>
+            <text x="462px" y="113px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>is</tspan><tspan fill="none">t</tspan><tspan>powered</tspan><tspan fill="none">t</tspan><tspan>by</tspan>
+            </text>
+        </g>
+    </g>
+
+<!-- Concepts -->
+    <g>
+        <rect x="649px" y="158px" rx="8" ry="8" width="52px" height="27px" stroke="none" fill="#edf4f6" stroke-width="0" />
+        <rect x="649px" y="158px" rx="8" ry="8" width="52px" height="27px" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <g>
+            <text x="656px" y="176px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>battery</tspan>
+            </text>
+        </g>
+    </g>
+    <g>
+        <rect x="282px" y="203px" rx="8" ry="8" width="33px" height="27px" stroke="none" fill="#edf4f6" stroke-width="0" />
+        <rect x="282px" y="203px" rx="8" ry="8" width="33px" height="27px" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <g>
+            <text x="289px" y="221px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>fuel</tspan>
+            </text>
+        </g>
+    </g>
+    <g>
+        <rect x="449px" y="160px" rx="8" ry="8" width="49px" height="27px" stroke="none" fill="#edf4f6" stroke-width="0" />
+        <rect x="449px" y="160px" rx="8" ry="8" width="49px" height="27px" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <g>
+            <text x="456px" y="178px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>engine</tspan>
+            </text>
+        </g>
+    </g>
+    <g>
+        <rect x="563px" y="46px" rx="8" ry="8" width="32px" height="27px" stroke="none" fill="#edf4f6" stroke-width="0" />
+        <rect x="563px" y="46px" rx="8" ry="8" width="32px" height="27px" stroke="#000000" fill="none" stroke-width="1" stroke-dasharray="none" />
+        <g>
+            <text x="570px" y="64px" stroke="none" fill="#000000" stroke-width="1" stroke-dasharray="none" alignment-baseline="auto" text-anchor="start" text-decoration="normal" font-weight="normal" font-style="normal" font-size="8pt" font-family="Verdana">
+                <tspan>Car</tspan>
+            </text>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Moving this to the right place again... sorry about the confusion!

Adds concept maps to mental models, modifies existing activity to step from analogies to concept maps in exploring mental models. Adds a figure.

To do yet:

- [x] remove concept maps from Memory episode
- [ ] fix bordering (at least) on new figure
- [ ] re-adjust timing estimates