### PR TITLE
remove phantom solution block

### DIFF
--- a/_episodes/09-eia.md
+++ b/_episodes/09-eia.md
@@ -127,7 +127,6 @@ The key to UDL is creating redundancies such that learners have multiple options
 > 
 > This exercise should take about 10 minutes.
 > 
-> {: .solution}
 {: .challenge}
 
 


### PR DESCRIPTION
There was a solution tag that was inside a challenge block with no corresponding solution. I removed it because it was throwing off my parser (to see if I can address #54), but let me know if you meant for it to be there. 